### PR TITLE
Reverse active/inactive tab background colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,13 +60,20 @@ exports.decorateConfig = (config) => {
         border: none !important;
       }
       .header_header {
-        background: ${inactiveTabBackgroundColor} !important;
+        background: ${backgroundColor} !important;
       }
       .splitpane_divider {
         background-color: rgba(130, 128, 184, 0.5) !important;
       }
       .tab_tab {
         border: 0;
+        background: ${inactiveTabBackgroundColor};
+      }
+      .tabs_list {
+        background: ${inactiveTabBackgroundColor};
+      }
+      .tab_active {
+        background-color: ${backgroundColor};
       }
       .tab_textActive {
         background-color: ${backgroundColor};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 // Constants
 const backgroundColor = '#0F1419';
+const inactiveTabBackgroundColor = '#0c0f12';
 const foregroundColor = '#e6e1cf';
 
 // Colors
@@ -59,7 +60,7 @@ exports.decorateConfig = (config) => {
         border: none !important;
       }
       .header_header {
-        background: ${backgroundColor} !important;
+        background: ${inactiveTabBackgroundColor} !important;
       }
       .splitpane_divider {
         background-color: rgba(130, 128, 184, 0.5) !important;
@@ -68,8 +69,8 @@ exports.decorateConfig = (config) => {
         border: 0;
       }
       .tab_textActive {
-        background-color: #0c0f12;
-        box-shadow: inset 2px 0 0 ${YELLOW}
+        background-color: ${backgroundColor};
+        box-shadow: inset 2px 0 0 ${YELLOW};
       }
       ${windowControlsCSS}
     `


### PR DESCRIPTION
This way, the active tab has the same background as the rest of the terminal background, and the inactive gets darker.

I've found myself often confused (especially with just two tabs, and even with the yellow left border) on which tab was actually active, because I expected the background to match the active tab background, but it was "in reverse".

I also put the color in a variable name to make it more explicit.

### Single tab
<img width="1552" alt="Screen Shot 2020-07-27 at 12 21 23" src="https://user-images.githubusercontent.com/1239616/88536463-c530a400-d003-11ea-8810-ef7486743ee8.png">

### Two tabs, first active
<img width="1552" alt="Screen Shot 2020-07-27 at 12 20 55" src="https://user-images.githubusercontent.com/1239616/88536486-cd88df00-d003-11ea-8df4-c13b12076391.png">

### Three tabs, second active
<img width="1552" alt="Screen Shot 2020-07-27 at 12 20 50" src="https://user-images.githubusercontent.com/1239616/88536525-dc6f9180-d003-11ea-8a43-042a1a8c33fa.png">
